### PR TITLE
Disable CAPI for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
                     - 8080:8080
                 env:
                     DISABLE_AGENT: true
+		    DISABLE_ONLINE_API: true
                 options: >-
                     --name crowdsec
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
                     - 8080:8080
                 env:
                     DISABLE_AGENT: true
-		    DISABLE_ONLINE_API: true
+                    DISABLE_ONLINE_API: true
                 options: >-
                     --name crowdsec
 


### PR DESCRIPTION
Disable CAPI when running tests to avoid 'fake' watchers registration.