### PR TITLE
close php session after boucing

### DIFF
--- a/src/StandAloneBounce.php
+++ b/src/StandAloneBounce.php
@@ -370,6 +370,10 @@ class StandAloneBounce extends AbstractBounce implements IBounce
             if ($this->debug) {
                 throw $e;
             }
+        } finally {
+            if (\PHP_SESSION_NONE !== session_status()) {
+                session_write_close();
+            }
         }
     }
 


### PR DESCRIPTION
To fix this bug https://wordpress.org/support/topic/warning-session_start-cannot-start-session-when-headers-already-sent/

We have to close the PHP session after boucing.