### PR TITLE
Feature/62 gregwar captcha fix for php81

### DIFF
--- a/examples/auto-prepend/scripts/bounce-via-auto-prepend.php
+++ b/examples/auto-prepend/scripts/bounce-via-auto-prepend.php
@@ -6,6 +6,7 @@ require_once __DIR__.'/../settings.php';
 use CrowdSecBouncer\StandAloneBounce;
 
 $bounce = new StandAloneBounce();
-$bounce->init($crowdSecStandaloneBouncerConfig);
 $bounce->setDebug($crowdSecStandaloneBouncerConfig['debug_mode']);
+$bounce->setDisplayErrors($crowdSecStandaloneBouncerConfig['display_errors']);
+$bounce->init($crowdSecStandaloneBouncerConfig);
 $bounce->safelyBounce();

--- a/src/Bouncer.php
+++ b/src/Bouncer.php
@@ -5,7 +5,7 @@ namespace CrowdSecBouncer;
 require_once __DIR__.'/templates/captcha.php';
 require_once __DIR__.'/templates/access-forbidden.php';
 
-use Gregwar\Captcha\CaptchaBuilder;
+use CrowdSecBouncer\Fixes\Gregwar\Captcha\CaptchaBuilder;
 use Gregwar\Captcha\PhraseBuilder;
 use IPLib\Factory;
 use Monolog\Handler\NullHandler;

--- a/src/Fixes/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Fixes/Gregwar/Captcha/CaptchaBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+
+namespace CrowdSecBouncer\Fixes\Gregwar\Captcha;
+
+use Gregwar\Captcha\CaptchaBuilder as GregwarCaptchaBuilder;
+
+/**
+ * Override to fix "implicit conversion error on PHP  8.1"
+ * @see https://github.com/crowdsecurity/php-cs-bouncer/issues/62 and
+ * @see https://github.com/Gregwar/Captcha/pull/101/files
+ *
+ */
+class CaptchaBuilder extends GregwarCaptchaBuilder {
+
+
+    /**
+     * Writes the phrase on the image
+     */
+    protected function writePhrase($image, $phrase, $font, $width, $height)
+    {
+        $length = mb_strlen($phrase);
+        if ($length === 0) {
+            return \imagecolorallocate($image, 0, 0, 0);
+        }
+
+        // Gets the text size and start position
+        $size = (int) round($width / $length) - $this->rand(0, 3) - 1;
+        $box = \imagettfbbox($size, 0, $font, $phrase);
+        $textWidth = $box[2] - $box[0];
+        $textHeight = $box[1] - $box[7];
+        $x = (int) round(($width - $textWidth) / 2);
+        $y = (int) round(($height - $textHeight) / 2) + $size;
+
+        if (!$this->textColor) {
+            $textColor = array($this->rand(0, 150), $this->rand(0, 150), $this->rand(0, 150));
+        } else {
+            $textColor = $this->textColor;
+        }
+        $col = \imagecolorallocate($image, $textColor[0], $textColor[1], $textColor[2]);
+
+        // Write the letters one by one, with random angle
+        for ($i=0; $i<$length; $i++) {
+            $symbol = mb_substr($phrase, $i, 1);
+            $box = \imagettfbbox($size, 0, $font, $symbol);
+            $w = $box[2] - $box[0];
+            $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
+            $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
+            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            $x += $w;
+        }
+
+        return $col;
+    }
+
+
+    /**
+     * Returns a random number or the next number in the
+     * fingerprint
+     */
+    protected function rand($min, $max)
+    {
+        if (!is_array($this->fingerprint)) {
+            $this->fingerprint = array();
+        }
+
+        if ($this->useFingerprint) {
+            $value = current($this->fingerprint);
+            next($this->fingerprint);
+        } else {
+            $value = mt_rand((int) $min, (int) $max);
+            $this->fingerprint[] = $value;
+        }
+
+        return $value;
+    }
+
+}

--- a/src/StandAloneBounce.php
+++ b/src/StandAloneBounce.php
@@ -2,6 +2,7 @@
 
 namespace CrowdSecBouncer;
 
+use ErrorException;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
@@ -356,7 +357,7 @@ class StandAloneBounce extends AbstractBounce implements IBounce
         // If there is any technical problem while bouncing, don't block the user. Bypass boucing and log the error.
         try {
             set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-                throw new BouncerException($errstr, $errno, 0, $errfile, $errline);
+                throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
             });
             $this->run();
             restore_error_handler();

--- a/src/StandAloneBounce.php
+++ b/src/StandAloneBounce.php
@@ -121,7 +121,7 @@ class StandAloneBounce extends AbstractBounce implements IBounce
             $maxRemediationLevel = Constants::REMEDIATION_BAN;
             break;
         default:
-            throw new \Exception("Unknown $bouncingLevel");
+            throw new BouncerException("Unknown $bouncingLevel");
     }
 
         // Instanciate the bouncer
@@ -343,7 +343,7 @@ class StandAloneBounce extends AbstractBounce implements IBounce
                 header('Pragma: no-cache');
                 break;
             default:
-                throw new \Exception("Unhandled code ${statusCode}");
+                throw new BouncerException("Unhandled code $statusCode");
         }
         if (null !== $body) {
             echo $body;

--- a/src/StandAloneBounce.php
+++ b/src/StandAloneBounce.php
@@ -2,7 +2,6 @@
 
 namespace CrowdSecBouncer;
 
-use ErrorException;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
@@ -122,7 +121,7 @@ class StandAloneBounce extends AbstractBounce implements IBounce
             $maxRemediationLevel = Constants::REMEDIATION_BAN;
             break;
         default:
-            throw new Exception("Unknown $bouncingLevel");
+            throw new \Exception("Unknown $bouncingLevel");
     }
 
         // Instanciate the bouncer
@@ -344,7 +343,7 @@ class StandAloneBounce extends AbstractBounce implements IBounce
                 header('Pragma: no-cache');
                 break;
             default:
-                throw new Exception("Unhandled code ${statusCode}");
+                throw new \Exception("Unhandled code ${statusCode}");
         }
         if (null !== $body) {
             echo $body;
@@ -354,10 +353,10 @@ class StandAloneBounce extends AbstractBounce implements IBounce
 
     public function safelyBounce(): void
     {
-        // If there is any technical problem while bouncing, don't block the user. Bypass boucing and log the error.
+        // If there is any technical problem while bouncing, don't block the user. Bypass bouncing and log the error.
         try {
-            set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-                throw new ErrorException($errstr, $errno, 0, $errfile, $errline);
+            set_error_handler(function ($errno, $errstr) {
+                throw new BouncerException("$errstr (Error level: $errno)");
             });
             $this->run();
             restore_error_handler();


### PR DESCRIPTION
- Override `gregwar/captcha` `CaptchaBuilder` class to avoid "implicit conversion" error on PHP 8.1

- Modify `set_error_handler` as `BouncerException` construct method has not enough arguments

@see https://github.com/crowdsecurity/php-cs-bouncer/issues/62